### PR TITLE
Better handling of API error messages

### DIFF
--- a/lib/gocardless/errors.rb
+++ b/lib/gocardless/errors.rb
@@ -10,14 +10,33 @@ module GoCardless
     def initialize(response)
       @response = response
       @code = response.status
-      body = MultiJson.decode(response.body) rescue nil
-      if body.is_a? Hash
-        @description = body["error"] || response.body.strip || "Unknown error"
+
+      begin
+        parsed_response = MultiJson.decode(response.body)
+        errors = parsed_response["error"] || parsed_response["errors"]
+        @description = stringify_errors(errors)
+      rescue MultiJson::ParseError
+        @description = response.body ? response.body.strip : "Unknown error"
       end
     end
 
     def to_s
       "#{super} [#{self.code}] #{self.description}"
+    end
+
+    private
+
+    def stringify_errors(errors)
+      case errors
+      when Array
+        errors.join(", ")
+      when Hash
+        errors.flat_map do |field, messages|
+          messages.map { |message| "#{field} #{message}" }
+        end.join(", ")
+      else
+        errors.to_s
+      end
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe GoCardless::ApiError do
+  let(:response) { double(body: body, status: 500) }
+  let(:error) { GoCardless::ApiError.new(response) }
+
+  describe "#description" do
+    subject { error.description }
+
+    context "given no response body" do
+      let(:body) { nil }
+      it { is_expected.to eq "Unknown error" }
+    end
+
+    context "given a json response body with an 'errors' hash" do
+      let(:body) do
+        MultiJson.dump(errors: { name: ["too short"], email: ["taken", "invalid"] })
+      end
+      it { is_expected.to eq "name too short, email taken, email invalid" }
+    end
+
+    context "given a json response body with an 'error' array" do
+      let(:body) { MultiJson.dump(error: ["Server Error", "Oops"]) }
+      it { is_expected.to eq "Server Error, Oops" }
+    end
+
+    context "with a non-JSON body" do
+      let(:body) { "non-json body" }
+      it { is_expected.to eq "non-json body" }
+    end
+  end
+end


### PR DESCRIPTION
- Detect errors under the `errors` key, as well as under `error`
- Handle field errors that come as a hash, as well as arrays of error messages

Review please @petehamilton.